### PR TITLE
Set raw txt file permissions to public-read.

### DIFF
--- a/storage/digital_ocean_spaces.py
+++ b/storage/digital_ocean_spaces.py
@@ -72,8 +72,7 @@ class DigitalOceanSpaces(StorageInterface):
         logging.debug(f"Getting {file_key}")
         self._client.download_fileobj(self._bucket, file_key, destination)
 
-
-    def upload_content(self, file_key: str, content_to_be_uploaded: str) -> None:
+    def upload_content(self, file_key: str, content_to_be_uploaded: str, permission: str ="public-read") -> None:
         logging.debug(f"Uploading {file_key}")
         f = BytesIO(content_to_be_uploaded.encode())
-        self._client.upload_fileobj(f, self._bucket, file_key)
+        self._client.upload_fileobj(f, self._bucket, file_key, ExtraArgs={"ACL": permission})


### PR DESCRIPTION
When uploading the raw text files to the storage system, the files should be public to read. Allowing the front end to access them. This commit ensures the right permissions.

The current implementation should be improved by getting the permissions from configuration or another proper external source.