### PR TITLE
Cria usuário 'gazette' com o mesmo UID do usuário do host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ black:
 .PHONY: build-devel
 build-devel:
 	podman build --tag $(IMAGE_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG) \
+		--build-arg GAZETTE_UID=$(UID) \
 		-f scripts/Dockerfile $(PWD)
 
 .PHONY: build-tika-server

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,6 +1,7 @@
 FROM docker.io/python:3.8
 
-RUN adduser --system gazette && \
+ARG GAZETTE_UID
+RUN adduser --system --uid $GAZETTE_UID gazette && \
 	apt-get update -y && \
   curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
 	apt-get -y install git-lfs wait-for-it && \


### PR DESCRIPTION
Evita o erro "Path /root/models/bert-base-portuguese-cased not found" ao executar "make re-run", devido ao usuário gazette ter um UID diferente do usuário do host.