### PR TITLE
querido-diario-data-processing para Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,16 +37,6 @@ run-command=(podman run --rm -ti --volume $(PWD):/mnt/code:rw \
 	--env POSTGRES_PORT=$(POSTGRES_PORT) \
 	$(IMAGE_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG) $1)
 
-wait-for=(podman run --rm -ti --volume $(PWD):/mnt/code:rw \
-	--pod $(POD_NAME) \
-	--env PYTHONPATH=/mnt/code \
-	--env POSTGRES_PASSWORD=$(POSTGRES_PASSWORD) \
-	--env POSTGRES_USER=$(POSTGRES_USER) \
-	--env POSTGRES_DB=$(POSTGRES_DB) \
-	--env POSTGRES_HOST=$(POSTGRES_HOST) \
-	--env POSTGRES_PORT=$(POSTGRES_PORT) \
-	$(IMAGE_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG) wait-for-it --timeout=60 $1)
-
 .PHONY: black
 black:
 	podman run --rm -ti --volume $(PWD):/mnt/code:rw \
@@ -197,7 +187,7 @@ else
 endif
 
 set-run-variable-values:
-	cp --no-clobber contrib/sample.env envvars || true
+	copy /y contrib\sample.env envvars
 	$(eval POD_NAME=run-$(POD_NAME))
 	$(eval DATABASE_CONTAINER_NAME=run-$(DATABASE_CONTAINER_NAME))
 	$(eval ELASTICSEARCH_CONTAINER_NAME=run-$(ELASTICSEARCH_CONTAINER_NAME))

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/python:3.8
+FROM docker.io/python:3.10
 
 ENV USER gazette
 ENV USER_HOME /home/$USER

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,11 @@
+black==19.10b0
+coverage==5.2.1
+python-magic==0.4.18
+boto3==1.22.6
+psycopg2==2.8.6
+botocore==1.25.6
+elasticsearch==7.17.3
+requests==2.25.0
+scikit-learn==1.0.2 
+sentence-transformers==2.2.0
+huggingface-hub==0.10.1  # fix: https://github.com/UKPLab/sentence-transformers/issues/1762


### PR DESCRIPTION
O MakeFile tem alguns comandos diferentes incluindo a remoção de "cp":
substituir cp --no-clobber contrib/sample.env envvars || true POR copy /y contrib\sample.env envvars

O comando "wait-for" substituído por:
run-command=(podman run --rm -ti --volume $(PWD):/mnt/code:rw \
	--pod $(POD_NAME) \
	--env PYTHONPATH=/mnt/code \
	--env POSTGRES_PASSWORD=$(POSTGRES_PASSWORD) \
	--env POSTGRES_USER=$(POSTGRES_USER) \
	--env POSTGRES_DB=$(POSTGRES_DB) \
	--env POSTGRES_HOST=$(POSTGRES_HOST) \
	--env POSTGRES_PORT=$(POSTGRES_PORT) \
	$(IMAGE_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG) $1)

Além disso, foi necessário deixar requirements.txt na pasta scripts. O comando COPY no DockerFile não funcionou para Windows.

Não testei todas as funcionalidades do data-processing, mas **não dá** para fazer um merge direto pois existem essas mudanças no Makefile.
