### PR TITLE
Reduz tamanho das queries temáticas para menor uso de heap

### DIFF
--- a/tasks/utils/__init__.py
+++ b/tasks/utils/__init__.py
@@ -2,4 +2,5 @@ from .index import (
     get_documents_from_query_with_highlights,
     get_documents_with_ids,
 )
+from .iter import batched
 from .text import clean_extra_whitespaces

--- a/tasks/utils/iter.py
+++ b/tasks/utils/iter.py
@@ -1,0 +1,11 @@
+from itertools import islice
+
+
+def batched(iterable, n):
+    # batched('ABCDEFG', 3) --> ABC DEF G
+    # pode ser removido ao usar python 3.12, em favor de itertools.batched
+    if n < 1:
+        raise ValueError('n must be at least one')
+    it = iter(iterable)
+    while batch := tuple(islice(it, n)):
+        yield batch


### PR DESCRIPTION
Em produção, as queries que geram novas entradas em índices temáticos a partir de muitos documentos (exemplo: ao criar um novo índice a partir da base completa) estão atingindo o uso máximo do heap (atualmente 4GB).

Exemplo de log:
```
[2023-10-26T18:20:26,932][INFO ][o.e.i.b.HierarchyCircuitBreakerService] [elasticsearch] attempting to trigger G1GC due to high heap usage [3969385000]
[2023-10-26T18:20:26,963][INFO ][o.e.i.b.HierarchyCircuitBreakerService] [elasticsearch] GC did bring memory usage down, before [3969385000], after [998223872], allocations [43], duration [31]
```

Por conta desse circuit breaker do elasticsearch, o scroll da query desaparece e eventualmente as queries resultam em erro por falha na conexão.

Este PR visa diminuir o uso do heap diminuindo a complexidade da query tanto no parâmetro `size` da query quanto no número de documentos utilizados para que a query seja realizada.