### PR TITLE
Refatoração do processo de Segmentação

### DIFF
--- a/main/__main__.py
+++ b/main/__main__.py
@@ -6,11 +6,14 @@ from database import create_database_interface
 from storage import create_storage_interface
 from index import create_index_interface
 from tasks import (
+    create_gazettes_index,
+    create_themed_excerpts_index,
     embedding_rerank_excerpts,
     extract_text_from_gazettes,
     extract_themed_excerpts_from_gazettes,
     get_gazettes_to_be_processed,
     get_themes,
+    get_territories,
     tag_entities_in_excerpts,
 )
 
@@ -42,12 +45,15 @@ def execute_pipeline():
     text_extractor = create_apache_tika_text_extraction()
     themes = get_themes()
 
+    create_gazettes_index(index)
+    territories = get_territories(database)
     gazettes_to_be_processed = get_gazettes_to_be_processed(execution_mode, database)
     indexed_gazette_ids = extract_text_from_gazettes(
-        gazettes_to_be_processed, database, storage, index, text_extractor
+        gazettes_to_be_processed, territories, database, storage, index, text_extractor
     )
    
     for theme in themes:
+        create_themed_excerpts_index(theme, index)
         themed_excerpt_ids = extract_themed_excerpts_from_gazettes(
             theme, indexed_gazette_ids, index
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ requests==2.25.0
 scikit-learn==1.0.2 
 sentence-transformers==2.2.0
 huggingface-hub==0.10.1  # fix: https://github.com/UKPLab/sentence-transformers/issues/1762
+python-slugify[unidecode]==8.0.1

--- a/segmentation/base/association_segmenter.py
+++ b/segmentation/base/association_segmenter.py
@@ -1,11 +1,10 @@
-from typing import Union, Dict, List
+from typing import Any, Dict, Iterable, List, Union
 from segmentation.base import GazetteSegment
 
 
 class AssociationSegmenter:
-    def __init__(self, association_gazette: str, territory_to_data: Dict):
-        self.association_gazette = association_gazette
-        self.territory_to_data = territory_to_data
+    def __init__(self, territories: Iterable[Dict[str, Any]]):
+        self.territories = territories
 
     def get_gazette_segments(self, *args, **kwargs) -> List[Union[GazetteSegment, Dict]]:
         """

--- a/segmentation/factory.py
+++ b/segmentation/factory.py
@@ -1,30 +1,34 @@
-from typing import Any, Dict
+from typing import Any, Dict, Iterable
 
 from segmentation.base import AssociationSegmenter
 from segmentation import segmenters
 
 
-def get_segmenter(territory_id: str, association_gazzete: Dict[str, Any], territory_to_data: Dict) -> AssociationSegmenter:
+_segmenter_instances = {}
+
+
+def get_segmenter(territory_id: str, territories: Iterable[Dict[str, Any]]) -> AssociationSegmenter:
     """
     Factory method to return a AssociationSegmenter
 
     Example
     -------
-    >>> association_gazette = {
-        "territory_name": "Associação",
-        "created_at": datetime.datetime.now(),
-        "date": datetime.datetime.now(),
-        "edition_number": 1,
-        "file_path": 'raw/pdf.pdf',
-        "file_url": 'localhost:8000/raw/pdf.pdf',
-        "is_extra_edition": True,
-        "power": 'executive',
-        "scraped_at": datetime.datetime.now(),
-        "state_code": 'AL',
-        "source_text": texto,
-    }
+    >>> territory_id = "9999999"
+    >>> territories = [
+        {
+            "id": "9999999",
+            "territory_name": "Bairro do Limoeiro",
+            "state_code": "ZZ",
+            "state": "Limoeirolândia",
+        }, {
+            "id": "0000000",
+            "territory_name": "Castelo Rá-Tim-Bum",
+            "state_code": "SP",
+            "state": "São Paulo",
+        },
+    ]
     >>> from segmentation import get_segmenter
-    >>> segmenter = get_segmenter(territory_id, association_gazette)
+    >>> segmenter = get_segmenter(territory_id, territories)
     >>> segments = segmenter.get_gazette_segments()
 
     Notes
@@ -37,6 +41,9 @@ def get_segmenter(territory_id: str, association_gazzete: Dict[str, Any], territ
         "2700000": "ALAssociacaoMunicipiosSegmenter",
     }
 
-    segmenter_class_name = territory_to_segmenter_class[territory_id]
-    segmenter_class = getattr(segmenters, segmenter_class_name)
-    return segmenter_class(association_gazzete, territory_to_data)
+    if territory_id not in _segmenter_instances:
+        segmenter_class_name = territory_to_segmenter_class[territory_id]
+        segmenter_class = getattr(segmenters, segmenter_class_name)
+        _segmenter_instances[territory_id] = segmenter_class(territories)
+
+    return _segmenter_instances[territory_id]

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,3 +1,4 @@
+from .create_index import create_gazettes_index, create_themed_excerpts_index
 from .gazette_excerpts_embedding_reranking import embedding_rerank_excerpts
 from .gazette_excerpts_entities_tagging import tag_entities_in_excerpts
 from .gazette_text_extraction import extract_text_from_gazettes
@@ -10,3 +11,4 @@ from .interfaces import (
     TextExtractorInterface,
 )
 from .list_gazettes_to_be_processed import get_gazettes_to_be_processed
+from .list_territories import get_territories

--- a/tasks/create_index.py
+++ b/tasks/create_index.py
@@ -1,0 +1,153 @@
+from typing import Dict
+
+from .interfaces import IndexInterface
+
+
+def create_gazettes_index(index: IndexInterface) -> None:
+    body = {
+        "mappings": {
+            "properties": {
+                "created_at": {"type": "date"},
+                "date": {"type": "date"},
+                "edition_number": {
+                    "type": "text",
+                    "fields": {"keyword": {"type": "keyword", "ignore_above": 256}},
+                },
+                "file_checksum": {"type": "keyword"},
+                "file_path": {"type": "keyword"},
+                "file_url": {"type": "keyword"},
+                "id": {"type": "keyword"},
+                "is_extra_edition": {"type": "boolean"},
+                "power": {"type": "keyword"},
+                "processed": {"type": "boolean"},
+                "scraped_at": {"type": "date"},
+                "source_text": {
+                    "type": "text",
+                    "analyzer": "brazilian",
+                    "index_options": "offsets",
+                    "term_vector": "with_positions_offsets",
+                    "fields": {
+                        "with_stopwords": {
+                            "type": "text",
+                            "analyzer": "brazilian_with_stopwords",
+                            "index_options": "offsets",
+                            "term_vector": "with_positions_offsets",
+                        },
+                        "exact": {
+                            "type": "text",
+                            "analyzer": "exact",
+                            "index_options": "offsets",
+                            "term_vector": "with_positions_offsets",
+                        }
+                    },
+                },
+                "state_code": {"type": "keyword"},
+                "territory_id": {"type": "keyword"},
+                "territory_name": {
+                    "type": "text",
+                    "fields": {"keyword": {"type": "keyword", "ignore_above": 256}},
+                },
+                "url": {"type": "keyword"},
+            }
+        },
+        "settings": {
+            "index": {
+              "sort.field": ["territory_id", "date"],
+              "sort.order": ["asc", "desc"]
+            },
+            "analysis": {
+                "filter": {
+                    "brazilian_stemmer": {
+                        "type": "stemmer",
+                        "language": "brazilian",
+                    }
+                },
+                "analyzer": {
+                    "brazilian_with_stopwords": {
+                        "tokenizer": "standard",
+                        "filter": ["lowercase", "brazilian_stemmer"],
+                    },
+                    "exact": {
+                        "tokenizer": "standard",
+                        "filter": ["lowercase"],
+                    },
+                },
+            }
+        },
+    }
+    index.create_index(body=body)
+
+
+def create_themed_excerpts_index(theme: Dict, index: IndexInterface) -> None:
+    body = {
+        "mappings": {
+            "properties": {
+                "excerpt_embedding_score": {"type": "rank_feature"},
+                "excerpt_subthemes": {"type": "keyword"},
+                "excerpt_entities": {"type": "keyword"},
+                "excerpt": {
+                    "type": "text",
+                    "analyzer": "brazilian",
+                    "index_options": "offsets",
+                    "term_vector": "with_positions_offsets",
+                    "fields": {
+                        "with_stopwords": {
+                            "type": "text",
+                            "analyzer": "brazilian_with_stopwords",
+                            "index_options": "offsets",
+                            "term_vector": "with_positions_offsets",
+                        },
+                        "exact": {
+                            "type": "text",
+                            "analyzer": "exact",
+                            "index_options": "offsets",
+                            "term_vector": "with_positions_offsets",
+                        },
+                    },
+                },
+                "excerpt_id": {"type": "keyword"},
+                "source_database_id": {"type": "long"},
+                "source_index_id": {"type": "keyword"},
+                "source_created_at": {"type": "date"},
+                "source_date": {"type": "date"},
+                "source_edition_number": {"type": "keyword"},
+                "source_file_checksum": {"type": "keyword"},
+                "source_file_path": {"type": "keyword"},
+                "source_file_raw_txt": {"type": "keyword"},
+                "source_file_url": {"type": "keyword"},
+                "source_is_extra_edition": {"type": "boolean"},
+                "source_power": {"type": "keyword"},
+                "source_processed": {"type": "boolean"},
+                "source_scraped_at": {"type": "date"},
+                "source_state_code": {"type": "keyword"},
+                "source_territory_id": {"type": "keyword"},
+                "source_territory_name": {"type": "keyword"},
+                "source_url": {"type": "keyword"},
+            }
+        },
+        "settings": {
+            "index": {
+              "sort.field": ["source_territory_id", "source_date"],
+              "sort.order": ["asc", "desc"]
+            },
+            "analysis": {
+                "filter": {
+                    "brazilian_stemmer": {
+                        "type": "stemmer",
+                        "language": "brazilian",
+                    }
+                },
+                "analyzer": {
+                    "brazilian_with_stopwords": {
+                        "tokenizer": "standard",
+                        "filter": ["lowercase", "brazilian_stemmer"],
+                    },
+                    "exact": {
+                        "tokenizer": "standard",
+                        "filter": ["lowercase"],
+                    },
+                },
+            }
+        },
+    }
+    index.create_index(index_name=theme["index"], body=body)

--- a/tasks/gazette_themed_excerpts_extraction.py
+++ b/tasks/gazette_themed_excerpts_extraction.py
@@ -8,8 +8,6 @@ from .utils import clean_extra_whitespaces, get_documents_from_query_with_highli
 def extract_themed_excerpts_from_gazettes(
     theme: Dict, gazette_ids: List[str], index: IndexInterface
 ) -> List[str]:
-    create_index(theme, index)
-
     ids = []
     for theme_query in theme["queries"]:
         for excerpt in get_excerpts_from_gazettes_with_themed_query(
@@ -29,81 +27,6 @@ def extract_themed_excerpts_from_gazettes(
             ids.append(excerpt["excerpt_id"])
 
     return ids
-
-
-def create_index(theme: Dict, index: IndexInterface) -> None:
-    body = {
-        "mappings": {
-            "properties": {
-                "excerpt_embedding_score": {"type": "rank_feature"},
-                "excerpt_subthemes": {"type": "keyword"},
-                "excerpt_entities": {"type": "keyword"},
-                "excerpt": {
-                    "type": "text",
-                    "analyzer": "brazilian",
-                    "index_options": "offsets",
-                    "term_vector": "with_positions_offsets",
-                    "fields": {
-                        "with_stopwords": {
-                            "type": "text",
-                            "analyzer": "brazilian_with_stopwords",
-                            "index_options": "offsets",
-                            "term_vector": "with_positions_offsets",
-                        },
-                        "exact": {
-                            "type": "text",
-                            "analyzer": "exact",
-                            "index_options": "offsets",
-                            "term_vector": "with_positions_offsets",
-                        },
-                    },
-                },
-                "excerpt_id": {"type": "keyword"},
-                "source_database_id": {"type": "long"},
-                "source_index_id": {"type": "keyword"},
-                "source_created_at": {"type": "date"},
-                "source_date": {"type": "date"},
-                "source_edition_number": {"type": "keyword"},
-                "source_file_checksum": {"type": "keyword"},
-                "source_file_path": {"type": "keyword"},
-                "source_file_raw_txt": {"type": "keyword"},
-                "source_file_url": {"type": "keyword"},
-                "source_is_extra_edition": {"type": "boolean"},
-                "source_power": {"type": "keyword"},
-                "source_processed": {"type": "boolean"},
-                "source_scraped_at": {"type": "date"},
-                "source_state_code": {"type": "keyword"},
-                "source_territory_id": {"type": "keyword"},
-                "source_territory_name": {"type": "keyword"},
-                "source_url": {"type": "keyword"},
-            }
-        },
-        "settings": {
-            "index": {
-              "sort.field": ["source_territory_id", "source_date"],
-              "sort.order": ["asc", "desc"]
-            },
-            "analysis": {
-                "filter": {
-                    "brazilian_stemmer": {
-                        "type": "stemmer",
-                        "language": "brazilian",
-                    }
-                },
-                "analyzer": {
-                    "brazilian_with_stopwords": {
-                        "tokenizer": "standard",
-                        "filter": ["lowercase", "brazilian_stemmer"],
-                    },
-                    "exact": {
-                        "tokenizer": "standard",
-                        "filter": ["lowercase"],
-                    },
-                },
-            }
-        },
-    }
-    index.create_index(index_name=theme["index"], body=body)
 
 
 def get_excerpts_from_gazettes_with_themed_query(

--- a/tasks/list_territories.py
+++ b/tasks/list_territories.py
@@ -1,0 +1,28 @@
+from functools import lru_cache 
+from typing import Dict, Iterable
+from .interfaces import DatabaseInterface
+
+
+@lru_cache
+def get_territories(
+    database: DatabaseInterface,
+) -> Iterable[Dict]:
+    """
+    Example
+    -------
+    >>> territories = get_territories_gazettes(database)
+    """
+    command = """SELECT * FROM territories;"""
+    territories = [
+        _format_territories_data(territory) for territory in database.select(command)
+    ]
+    return territories
+
+
+def _format_territories_data(data):
+    return {
+        "id": data[0],
+        "territory_name": data[1],
+        "state_code": data[2],
+        "state": data[3],
+    }

--- a/tasks/utils/__init__.py
+++ b/tasks/utils/__init__.py
@@ -2,11 +2,14 @@ from .index import (
     get_documents_from_query_with_highlights,
     get_documents_with_ids,
 )
+from .python import (
+    batched,
+)
 from .text import (
     clean_extra_whitespaces,
     get_checksum,
 )
-
 from .territories import (
-    get_territory_to_data,
+    get_territory_slug,
+    get_territory_data,
 )

--- a/tasks/utils/python.py
+++ b/tasks/utils/python.py
@@ -1,0 +1,10 @@
+from itertools import islice
+
+
+def batched(iterable, n):
+    # batched('ABCDEFG', 3) --> ABC DEF G
+    if n < 1:
+        raise ValueError('n must be at least one')
+    it = iter(iterable)
+    while batch := tuple(islice(it, n)):
+        yield batch

--- a/tasks/utils/territories.py
+++ b/tasks/utils/territories.py
@@ -1,34 +1,42 @@
-from typing import Dict, Iterable
-from ..interfaces import DatabaseInterface
+from typing import Any, Dict, Iterable, Tuple, Union
+
+from slugify import slugify
 
 
-def get_territory_to_data(database: DatabaseInterface):
-    territories = _get_territories_gazettes(database)
-    territory_to_data = {
-        ((t["state_code"], t["territory_name"])): t
-        for t in territories
-    }
-    return territory_to_data
+_territory_slug_to_data_map = {}
 
 
-def _get_territories_gazettes(
-    database: DatabaseInterface,
-) -> Iterable[Dict]:
-    """
-    Example
-    -------
-    >>> territories = get_territories_gazettes(database)
-    """
-    command = """SELECT * FROM territories;"""
-    territories = [
-        _format_territories_data(territory) for territory in database.select(command)
-    ]
-    return territories
+def get_territory_slug(name: str, state_code: str) -> str:
+    full_name = f"{state_code} {name}"
+    stopwords = ["de", "d", "da", "do", "das", "dos"]
+    replacements = [("´", "'"), ("`", "'")]
+    return slugify(full_name, separator="", stopwords=stopwords, replacements=replacements)
 
 
-def _format_territories_data(data):
-    return {
-        "id": data[0],
-        "territory_name": data[1],
-        "state_code": data[2],
-    }
+def get_territory_data(identifier: Union[str, Tuple[str, str]], territories: Iterable[Dict[str, Any]]) -> Dict[str, Dict]:
+    if isinstance(identifier, tuple):
+        territory_name, state_code = identifier
+        territory_slug = get_territory_slug(territory_name, state_code)
+    elif isinstance(identifier, str):
+        territory_slug = identifier
+    else:
+        raise TypeError(f"Identifier must be 'str' or 'tuple'. Got: {type(identifier)}")
+
+    slug_to_data = get_territory_slug_to_data_map(territories)
+
+    if territory_slug not in slug_to_data:
+        raise KeyError(f"Couldn't find info for \"{territory_slug}\"")
+
+    return slug_to_data[territory_slug]
+
+
+def get_territory_slug_to_data_map(territories: Iterable[Dict[str, Any]]) -> Dict[str, Dict]:
+    global _territory_slug_to_data_map
+    if not _territory_slug_to_data_map:
+        territory_to_data = {
+            get_territory_slug(t["territory_name"], t["state_code"]): t
+            for t in territories
+        }
+        _territory_slug_to_data_map = territory_to_data
+
+    return _territory_slug_to_data_map


### PR DESCRIPTION
* Torna em task a listagem dos territórios através de consulta no banco de dados
* Torna uma util a função para obter os dados de um território a partir do nome
* Adicionar tratamento para casos em que o nome do município vem seguido de sufixos até então não mapeados
* Lança exceção caso o município não seja encontrado para que seja capturada e gere um erro no processamento do município
* Refatora a função `_fix_territory_name` que corrige a escrita dos nomes dos municípios quando existem erros conhecidos
* Refatora a função `extract_text_from_gazettes` na qual é feita a bifurcação do processamento de diários comuns ou associações
* Adicionar argumento `territories` para a função `ALAssociacaoMunicipiosSegmenter.get_gazette_segments`. Esta função é chamada na `try_process_gazette_association_file`