### PR TITLE
Corrige exclusão de scroll_id's não usados

### DIFF
--- a/index/opensearch.py
+++ b/index/opensearch.py
@@ -74,8 +74,13 @@ class OpenSearchInterface(IndexInterface):
         if len(result["hits"]["hits"]) == 0:
             return
 
+        scroll_id = None
         while len(result["hits"]["hits"]) > 0:
             yield result
+
+            if scroll_id is not None and scroll_id != result["_scroll_id"]:
+                self._search_engine.clear_scroll(scroll_id=scroll_id)
+
             scroll_id = result["_scroll_id"]
             result = self._search_engine.scroll(
                 scroll_id=scroll_id, scroll=keep_alive, request_timeout=120


### PR DESCRIPTION
O Opensearch de produção ainda está dando erro de scroll_id's e foi
identificado que a paginação não estava os excluindo corretamente.
