### PR TITLE
fix: Dockerfile_apache_tika

### DIFF
--- a/Dockerfile_apache_tika
+++ b/Dockerfile_apache_tika
@@ -1,6 +1,6 @@
 FROM docker.io/debian
 
-RUN adduser --system gazette && \
+RUN useradd --system --no-create-home --shell /usr/sbin/nologin gazette && \
 	apt-get update -y && \
 	apt-get -y install default-jre curl && \
 	apt-get clean


### PR DESCRIPTION
Com a nova versão do debian o comando adduser deixou de estar presente por padrão na imagem. Dessa forma, a melhor solução é passar a usar o comando useradd.