### PR TITLE
Add workflow to build multi-arch Apache Tika images

### DIFF
--- a/.github/workflows/build_apache_tika.yaml
+++ b/.github/workflows/build_apache_tika.yaml
@@ -1,0 +1,71 @@
+name: Build and Push Apache Tika Images
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Dockerfile_apache_tika'
+      - '.github/workflows/build_apache_tika.yaml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'Dockerfile_apache_tika'
+      - '.github/workflows/build_apache_tika.yaml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/apache-tika
+
+jobs:
+  build-and-push:
+    name: Build and push Apache Tika multi-arch image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Apache Tika image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile_apache_tika
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Creates a GitHub Actions workflow to build Apache Tika images for both AMD64 and ARM64 architectures and publish them to GitHub Container Registry.

Problem:
- The official apache/tika:2.9.1.0 image only supports AMD64
- ARM64 CI runners fail with 'exec format error'

Solution:
- Build from Dockerfile_apache_tika for both architectures
- Use QEMU for cross-platform builds with Docker Buildx
- Publish to ghcr.io/okfn-brasil/querido-diario-data-processing/apache-tika

The workflow:
- Triggers on changes to Dockerfile_apache_tika or this workflow file
- Can be triggered manually via workflow_dispatch
- Publishes images tagged as 'latest' when merging to main
- Includes build caching for faster subsequent builds

After merging, the image needs to be made public or repository access granted so CI workflows can pull it.