### PR TITLE
Fix Apache Tika version from 3.2.2 to 3.2.3

### DIFF
--- a/Dockerfile_apache_tika
+++ b/Dockerfile_apache_tika
@@ -12,7 +12,7 @@ RUN apt-get update -y && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install Apache Tika (cached separately for version updates)
-RUN curl -o /tika-server.jar https://dlcdn.apache.org/tika/3.2.2/tika-server-standard-3.2.2.jar && \
+RUN curl -o /tika-server.jar https://dlcdn.apache.org/tika/3.2.3/tika-server-standard-3.2.3.jar && \
 	chmod 755 /tika-server.jar
 
 USER gazette


### PR DESCRIPTION
The Tika 3.2.2 download URL returns 404, causing the jar file to be invalid/corrupt. Updated to 3.2.3 which is the current available version on dlcdn.apache.org.

This fixes the error:
'Error: Invalid or corrupt jarfile /tika-server.jar'

The multi-arch build workflow needs to be re-run after this is merged to rebuild the images with the correct Tika version.