### PR TITLE
fix: Remove uso de ACL nos uploads para S3

### DIFF
--- a/storage/digital_ocean_spaces.py
+++ b/storage/digital_ocean_spaces.py
@@ -101,7 +101,7 @@ class DigitalOceanSpaces(StorageInterface):
         if isinstance(content_to_be_uploaded, str):
             f = BytesIO(content_to_be_uploaded.encode())
             self._client.upload_fileobj(
-                f, self._bucket, file_key, ExtraArgs={"ACL": permission}
+                f, self._bucket, file_key
             )
             # Explicit cleanup
             f.close()
@@ -110,7 +110,6 @@ class DigitalOceanSpaces(StorageInterface):
                 content_to_be_uploaded,
                 self._bucket,
                 file_key,
-                ExtraArgs={"ACL": permission},
             )
 
     def upload_file(
@@ -121,7 +120,7 @@ class DigitalOceanSpaces(StorageInterface):
     ) -> None:
         logging.debug(f"Uploading {file_key}")
         self._client.upload_file(
-            file_path, self._bucket, file_key, ExtraArgs={"ACL": permission}
+            file_path, self._bucket, file_key
         )
 
     def upload_file_multipart(
@@ -134,7 +133,7 @@ class DigitalOceanSpaces(StorageInterface):
         logging.debug(f"Uploading {file_key} with multipart")
 
         multipart_upload = self._client.create_multipart_upload(
-            Bucket=self._bucket, Key=file_key, ACL=permission
+            Bucket=self._bucket, Key=file_key
         )
         upload_id = multipart_upload["UploadId"]
 

--- a/tests/digital_ocean_spaces.py
+++ b/tests/digital_ocean_spaces.py
@@ -149,5 +149,5 @@ class DigitalOceanSpacesIntegrationTests(TestCase):
         content_to_be_uploaded = "content of bucket"
         spaces.upload_content(file_key, content_to_be_uploaded)
         upload_fileobj_mock.assert_called_once_with(
-            sentinel.bytesio, self.BUCKET, file_key, ExtraArgs={"ACL": "public-read"}
+            sentinel.bytesio, self.BUCKET, file_key
         )


### PR DESCRIPTION
## Problema

Ao tentar fazer upload de arquivos para S3, ocorria o erro:
```
An error occurred (AccessControlListNotSupported) when calling the PutObject operation: 
The bucket does not allow ACLs
```

Isso acontece porque buckets S3 modernos frequentemente têm a configuração 'Object Ownership' definida como 'Bucket owner enforced', o que **desabilita ACLs completamente**.

## Solução

Esta PR remove todos os parâmetros ACL das operações de upload no módulo `storage/digital_ocean_spaces.py`:

- `upload_content()` - Removido `ExtraArgs={"ACL": permission}`
- `upload_file()` - Removido `ExtraArgs={"ACL": permission}`
- `upload_file_multipart()` - Removido parâmetro `ACL=permission`

## Como controlar acesso público agora?

O acesso público deve ser controlado através de **políticas de bucket** ao invés de ACLs em nível de objeto, seguindo as melhores práticas da AWS:

```json
{
  "Version": "2012-10-17",
  "Statement": [{
    "Sid": "PublicRead",
    "Effect": "Allow",
    "Principal": "*",
    "Action": "s3:GetObject",
    "Resource": "arn:aws:s3:::nome-do-bucket/*"
  }]
}
```

## Testes

- ✅ Testes unitários atualizados em `tests/digital_ocean_spaces.py`
- ✅ Código compatível com AWS S3, Digital Ocean Spaces e outros serviços S3-compatíveis

## Nota

Este não era um problema de permissão IAM faltante, mas sim uma incompatibilidade entre o código (que tentava definir ACLs) e a configuração do bucket (que desabilita ACLs).