### PR TITLE
ci: ignora erros de exportação do cache do GitHub Actions

### DIFF
--- a/.github/workflows/build_apache_tika.yaml
+++ b/.github/workflows/build_apache_tika.yaml
@@ -67,7 +67,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           load: ${{ matrix.platform == 'linux/amd64' }}
           cache-from: type=gha,scope=tika-test-${{ matrix.arch }}
-          cache-to: type=gha,mode=min,scope=tika-test-${{ matrix.arch }}
+          cache-to: type=gha,mode=min,scope=tika-test-${{ matrix.arch }},ignore-error=true
           build-args: |
             TIKA_VERSION=${{ inputs.tika_version || '3.2.2' }}
           tags: |
@@ -165,7 +165,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           cache-from: type=gha,scope=tika-main-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=tika-main-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=tika-main-${{ matrix.arch }},ignore-error=true
           build-args: |
             TIKA_VERSION=${{ inputs.tika_version || '3.2.2' }}
             BUILD_DATE=${{ steps.meta.outputs.build_date }}
@@ -182,7 +182,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           cache-from: type=gha,scope=tika-tag-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=tika-tag-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=tika-tag-${{ matrix.arch }},ignore-error=true
           build-args: |
             TIKA_VERSION=${{ inputs.tika_version || '3.2.2' }}
             BUILD_DATE=${{ steps.meta.outputs.build_date }}

--- a/.github/workflows/build_base_image.yaml
+++ b/.github/workflows/build_base_image.yaml
@@ -75,7 +75,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           cache-from: type=gha,scope=base-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=base-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=base-${{ matrix.arch }},ignore-error=true
           build-args: |
             BUILD_DATE=${{ steps.meta.outputs.build_date }}
             VCS_REF=${{ steps.meta.outputs.vcs_ref }}

--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -95,7 +95,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           cache-from: type=gha,scope=app-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=app-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=app-${{ matrix.arch }},ignore-error=true
           build-args: |
             BUILD_DATE=${{ steps.meta.outputs.build_date }}
             VCS_REF=${{ steps.meta.outputs.vcs_ref }}


### PR DESCRIPTION
Adiciona ignore-error=true em todos os cache-to para evitar que indisponibilidade temporária do serviço de cache do GHA quebre o build.