### PR TITLE
fix: processa diários em ordem decrescente de inserção no banco

### DIFF
--- a/tasks/list_gazettes_to_be_processed.py
+++ b/tasks/list_gazettes_to_be_processed.py
@@ -61,7 +61,7 @@ def get_gazettes_extracted_since_yesterday(
         WHERE
             scraped_at > current_timestamp - interval '1 day'
             AND gazettes.file_path NOT LIKE '%.zip'
-        ORDER BY gazettes.id
+        ORDER BY gazettes.id DESC
         LIMIT {page_size} OFFSET {offset}
         ;
         """
@@ -121,7 +121,7 @@ def get_all_gazettes_extracted(
         INNER JOIN territories ON territories.id = gazettes.territory_id
         WHERE
             gazettes.file_path NOT LIKE '%.zip'
-        ORDER BY gazettes.id
+        ORDER BY gazettes.id DESC
         LIMIT {page_size} OFFSET {offset}
         ;
         """
@@ -182,7 +182,7 @@ def get_unprocessed_gazettes(
         WHERE
             processed is False
             AND gazettes.file_path NOT LIKE '%.zip'
-        ORDER BY gazettes.id
+        ORDER BY gazettes.id DESC
         LIMIT {page_size} OFFSET {offset}
         ;
         """


### PR DESCRIPTION
## Summary

- Altera o `ORDER BY gazettes.id` de `ASC` para `DESC` nos três modos de execução (`DAILY`, `ALL`, `UNPROCESSED`)
- Garante que os diários inseridos mais recentemente no banco sejam processados primeiro
- A paginação por `LIMIT/OFFSET` continua funcionando normalmente com a nova ordenação

## Arquivos alterados

- `tasks/list_gazettes_to_be_processed.py` — 3 queries afetadas (`get_gazettes_extracted_since_yesterday`, `get_all_gazettes_extracted`, `get_unprocessed_gazettes`)

## Test plan

- [ ] Verificar que o modo `UNPROCESSED` processa diários recentes antes dos antigos
- [ ] Verificar que o modo `DAILY` mantém comportamento correto de paginação
- [ ] Verificar que o modo `ALL` percorre todos os registros sem duplicatas ou saltos

🤖 Generated with [Claude Code](https://claude.com/claude-code)