### PR TITLE
fix: adiciona file_raw_txt ao mapping de gazettes

### DIFF
--- a/tasks/create_index.py
+++ b/tasks/create_index.py
@@ -23,6 +23,7 @@ def create_gazettes_index(index: IndexInterface) -> None:
                 },
                 "file_checksum": {"type": "keyword"},
                 "file_path": {"type": "keyword"},
+                "file_raw_txt": {"type": "keyword"},
                 "file_url": {"type": "keyword"},
                 "id": {"type": "keyword"},
                 "is_extra_edition": {"type": "boolean"},

--- a/tests/create_index_task_tests.py
+++ b/tests/create_index_task_tests.py
@@ -1,0 +1,16 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from tasks.create_index import create_gazettes_index
+
+
+class CreateIndexTaskTests(TestCase):
+    def test_gazettes_index_maps_raw_text_file_as_keyword(self):
+        index = MagicMock()
+
+        create_gazettes_index(index)
+
+        body = index.create_index.call_args.kwargs["body"]
+        properties = body["mappings"]["properties"]
+
+        self.assertEqual(properties["file_raw_txt"], {"type": "keyword"})


### PR DESCRIPTION
## O que foi alterado

- declara `file_raw_txt` como `keyword` no mapping do índice principal de gazettes
- adiciona teste unitário para garantir que o campo faça parte do corpo enviado à criação do índice

O campo já é produzido pela extração de texto; a declaração explícita evita que o OpenSearch infira um tipo diferente.

## Validação

- `python -m unittest discover -s tests -p create_index_task_tests.py`
- `ruff check tasks/create_index.py tests/create_index_task_tests.py`
- `ruff format --check tests/create_index_task_tests.py`

Closes #75